### PR TITLE
Remove stripPackageName to allow specify package version.

### DIFF
--- a/generators/app/src/modules.js
+++ b/generators/app/src/modules.js
@@ -74,7 +74,7 @@ module.exports = function (AngularWebpackES6Generator) {
           }
         }, this);
       } else if (utils.isHasPackage(section)) {
-        this.importList.push(utils.stripPackageName(section.package));
+        this.importList.push(section.package);
       }
 
     }.bind(this));


### PR DESCRIPTION
Remove stripPackageName to allow specify package version in the prompts.json

This commit fixes jQuery version.
Previously if user chose "jQuery 1.x" or "jQuery 2.x" the generator will install a "jQuery 3.x".